### PR TITLE
fix: #766 — AttestationCard + ComplianceReportScreen linked from robot detail

### DIFF
--- a/ios/Flutter/flutter_export_environment.sh
+++ b/ios/Flutter/flutter_export_environment.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 # This is a generated file; do not edit or check into version control.
 export "FLUTTER_ROOT=/home/craigm26/flutter"
-export "FLUTTER_APPLICATION_PATH=/home/craigm26/opencastor-client"
+export "FLUTTER_APPLICATION_PATH=/tmp/client-routing"
 export "COCOAPODS_PARALLEL_CODE_SIGN=true"
 export "FLUTTER_TARGET=lib/main.dart"
 export "FLUTTER_BUILD_DIR=build"
-export "FLUTTER_BUILD_NAME=1.0.0"
-export "FLUTTER_BUILD_NUMBER=1"
+export "FLUTTER_BUILD_NAME=1.3.0"
+export "FLUTTER_BUILD_NUMBER=6"
 export "DART_OBFUSCATION=false"
 export "TRACK_WIDGET_CREATION=true"
 export "TREE_SHAKE_ICONS=false"

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -33,7 +33,6 @@ import 'ui/harness/harness_viewer.dart';
 import 'ui/robot_capabilities/ai_screen.dart';
 import 'ui/robot_capabilities/contribute_screen.dart';
 import 'ui/robot_capabilities/conformance_screen.dart';
-import 'ui/robot_detail/attestation_card.dart' show AttestationCard;
 import 'ui/robot_detail/compliance_report_screen.dart';
 import 'ui/robot_detail/orchestrator_screen.dart';
 import 'ui/robot_capabilities/hardware_screen.dart';
@@ -249,6 +248,12 @@ final _routerProvider = Provider<GoRouter>((ref) {
           ),
           GoRoute(
             path: '/robot/:rrn/compliance-report',
+            builder: (_, state) =>
+                ComplianceReportScreen(rrn: state.pathParameters['rrn']!),
+          ),
+          GoRoute(
+            // #766: direct deep-link to compliance report (alias)
+            path: '/robot/:rrn/attestation',
             builder: (_, state) =>
                 ComplianceReportScreen(rrn: state.pathParameters['rrn']!),
           ),

--- a/lib/ui/robot_detail/robot_detail_screen.dart
+++ b/lib/ui/robot_detail/robot_detail_screen.dart
@@ -40,6 +40,8 @@ import 'robot_detail_view_model.dart';
 import 'slash_command_palette.dart';
 import 'slash_command_provider.dart';
 import '../fleet_leaderboard/personal_research_card.dart';
+import 'attestation_card.dart';
+import 'compliance_report_screen.dart';
 
 enum _RobotAction { control, share, docs, capabilities, harness }
 
@@ -833,6 +835,21 @@ class _RobotDetailScreenState extends ConsumerState<RobotDetailScreen> {
 
           // ── Personal Research mini-card ───────────────────────────────────
           PersonalResearchMiniCard(rrn: widget.rrn),
+
+          // ── RCAN v2.2 Attestation (closes #766) ──────────────────────────
+          AttestationCard(robot: robot),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: OutlinedButton.icon(
+              icon: const Icon(Icons.fact_check_outlined, size: 16),
+              label: const Text('View Full Compliance Report'),
+              style: OutlinedButton.styleFrom(
+                minimumSize: const Size.fromHeight(36),
+                textStyle: const TextStyle(fontSize: 13),
+              ),
+              onPressed: () => context.push('/robot/\${robot.rrn}/compliance-report'),
+            ),
+          ),
 
           // ── Chat input with slash command palette ─────────────────────────
           if (robot.hasCapability(RobotCapability.chat) &&


### PR DESCRIPTION
## Changes

- `robot_detail_screen.dart`: AttestationCard rendered below PersonalResearchMiniCard for every robot
- 'View Full Compliance Report' button navigates to `/robot/:rrn/compliance-report`
- `app.dart`: adds `/robot/:rrn/attestation` alias route for deep-link compat
- `app.dart`: removes stale AttestationCard import (now in robot_detail_screen)

Closes #766