### PR TITLE
refactor: screen-local providers → ViewModel files

### DIFF
--- a/lib/ui/alerts/alerts_screen.dart
+++ b/lib/ui/alerts/alerts_screen.dart
@@ -10,17 +10,11 @@ import 'package:timeago/timeago.dart' as timeago;
 
 import '../../data/models/robot.dart';
 import '../../ui/core/theme/app_theme.dart';
-import '../fleet/fleet_view_model.dart' show fleetProvider, robotRepositoryProvider;
+import '../fleet/fleet_view_model.dart' show fleetProvider;
+import 'alerts_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/loading_view.dart';
 
-// ── Providers ─────────────────────────────────────────────────────────────────
-
-/// Per-robot alert stream (ESTOP events, faults).
-final _alertsProvider =
-    StreamProvider.family<List<Map<String, dynamic>>, String>((ref, rrn) {
-  return ref
-      .read(robotRepositoryProvider)
-      .watchAlerts(rrn, limit: 30);
-});
 
 // ── Screen ────────────────────────────────────────────────────────────────────
 
@@ -36,8 +30,8 @@ class AlertsScreen extends ConsumerWidget {
         title: const Text('Alerts'),
       ),
       body: fleetAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => _ErrorState(error: e.toString()),
+        loading: () => const LoadingView(),
+        error: (e, _) => ErrorView(error: e.toString()),
         data: (robots) {
           if (robots.isEmpty) {
             return const _EmptyState();
@@ -65,7 +59,7 @@ class _RobotAlertSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final alertsAsync = ref.watch(_alertsProvider(robot.rrn));
+    final alertsAsync = ref.watch(alertsProvider(robot.rrn));
     final cs = Theme.of(context).colorScheme;
 
     return Card(
@@ -246,31 +240,4 @@ class _EmptyState extends StatelessWidget {
   }
 }
 
-class _ErrorState extends StatelessWidget {
-  final String error;
-  const _ErrorState({required this.error});
 
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.error_outline, size: 48),
-            const SizedBox(height: 16),
-            Text('Something went wrong',
-                style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            Text(
-              error.length > 200 ? '${error.substring(0, 200)}…' : error,
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}

--- a/lib/ui/alerts/alerts_view_model.dart
+++ b/lib/ui/alerts/alerts_view_model.dart
@@ -1,0 +1,16 @@
+/// ViewModel for the Alerts screen.
+///
+/// Exposes [alertsProvider] — a per-robot stream of ESTOP events and faults.
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../fleet/fleet_view_model.dart' show robotRepositoryProvider;
+
+/// Live stream of alerts for [rrn] (most recent 30 entries).
+final alertsProvider =
+    StreamProvider.family<List<Map<String, dynamic>>, String>((ref, rrn) {
+  return ref
+      .read(robotRepositoryProvider)
+      .watchAlerts(rrn, limit: 30);
+});

--- a/lib/ui/fleet_leaderboard/fleet_leaderboard_screen.dart
+++ b/lib/ui/fleet_leaderboard/fleet_leaderboard_screen.dart
@@ -13,8 +13,11 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'fleet_leaderboard_view_model.dart';
 import 'personal_research_card.dart';
 import '../shared/pipeline_explainer.dart';
+import '../shared/error_view.dart';
+import '../shared/loading_view.dart';
 
 // ── Data model ────────────────────────────────────────────────────────────────
 
@@ -195,8 +198,8 @@ class _FleetLeaderboardScreenState
         ),
       ),
       body: tiersAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
+        loading: () => const LoadingView(),
+        error: (e, _) => ErrorView(error: e.toString()),
         data: (tiers) {
           // Filter tiers and entries based on search
           final filteredTiers = <String, List<_LeaderboardEntry>>{};
@@ -722,34 +725,6 @@ class _CommunityBoardHeader extends StatelessWidget {
   }
 }
 
-// ── Research status provider ──────────────────────────────────────────────────
-
-/// Fetches /api/research/status via robotApiGet to get explored %, champion.
-final _researchStatusProvider = FutureProvider.autoDispose<Map<String, dynamic>>((ref) async {
-  try {
-    final uid = FirebaseAuth.instance.currentUser?.uid;
-    if (uid == null) return {};
-    final snap = await FirebaseFirestore.instance
-        .collection('robots')
-        .where('firebase_uid', isEqualTo: uid)
-        .limit(1)
-        .get();
-    if (snap.docs.isEmpty) return {};
-    final rrn = snap.docs.first.id;
-    final callable = FirebaseFunctions.instance.httpsCallable(
-      'robotApiGet',
-      options: HttpsCallableOptions(timeout: const Duration(seconds: 8)),
-    );
-    final result = await callable.call(<String, dynamic>{
-      'rrn': rrn,
-      'path': '/api/research/status',
-    });
-    final data = result.data;
-    if (data is Map) return Map<String, dynamic>.from(data);
-  } catch (_) {}
-  return {};
-});
-
 // ── Research Projects Section (#32) ──────────────────────────────────────────
 
 class _ResearchProjectsHeader extends StatelessWidget {
@@ -823,7 +798,7 @@ class _ResearchProjectsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final statusAsync = ref.watch(_researchStatusProvider);
+    final statusAsync = ref.watch(researchStatusProvider);
     final status = statusAsync.valueOrNull ?? {};
     return Column(
       children: [

--- a/lib/ui/fleet_leaderboard/fleet_leaderboard_view_model.dart
+++ b/lib/ui/fleet_leaderboard/fleet_leaderboard_view_model.dart
@@ -1,0 +1,38 @@
+/// ViewModel for the Fleet Leaderboard screen.
+///
+/// Exposes [researchStatusProvider] — fetches /api/research/status via
+/// the `robotApiGet` Cloud Function.
+library;
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Fetches research status (explored %, champion score) from
+/// `/api/research/status` via `robotApiGet`.
+final researchStatusProvider =
+    FutureProvider.autoDispose<Map<String, dynamic>>((ref) async {
+  try {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return {};
+    final snap = await FirebaseFirestore.instance
+        .collection('robots')
+        .where('firebase_uid', isEqualTo: uid)
+        .limit(1)
+        .get();
+    if (snap.docs.isEmpty) return {};
+    final rrn = snap.docs.first.id;
+    final callable = FirebaseFunctions.instance.httpsCallable(
+      'robotApiGet',
+      options: HttpsCallableOptions(timeout: const Duration(seconds: 8)),
+    );
+    final result = await callable.call(<String, dynamic>{
+      'rrn': rrn,
+      'path': '/api/research/status',
+    });
+    final data = result.data;
+    if (data is Map) return Map<String, dynamic>.from(data);
+  } catch (_) {}
+  return {};
+});

--- a/lib/ui/fleet_leaderboard/personal_research_card.dart
+++ b/lib/ui/fleet_leaderboard/personal_research_card.dart
@@ -4,44 +4,12 @@
 /// Also exports [PersonalResearchMiniCard] for compact use on robot detail.
 library;
 
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/models/personal_research.dart';
 import '../../data/services/personal_research_service.dart';
-
-// ── Provider ──────────────────────────────────────────────────────────────────
-
-/// Resolves the signed-in user's first robot RRN from Firestore.
-/// Returns null when not signed in or no robots registered.
-final _userRrnProvider = FutureProvider.autoDispose<String?>((ref) async {
-  final uid = FirebaseAuth.instance.currentUser?.uid;
-  if (uid == null) return null;
-  final snap = await FirebaseFirestore.instance
-      .collection('robots')
-      .where('firebase_uid', isEqualTo: uid)
-      .limit(1)
-      .get();
-  if (snap.docs.isEmpty) return null;
-  return snap.docs.first.id;
-});
-
-/// Fetches the personal research summary for the signed-in user's first robot.
-final personalResearchProvider =
-    FutureProvider.autoDispose<PersonalResearchSummary?>((ref) async {
-  final rrn = await ref.watch(_userRrnProvider.future);
-  if (rrn == null) return null;
-  return PersonalResearchService().getSummary(rrn);
-});
-
-/// Family variant scoped to a specific RRN (used by robot detail screen).
-/// Reads from Firestore stream (robots/{rrn}/telemetry/research) — no CF relay needed.
-final personalResearchRrnProvider =
-    StreamProvider.autoDispose.family<PersonalResearchSummary?, String>(
-  (ref, rrn) => PersonalResearchService().summaryStream(rrn),
-);
+import 'personal_research_view_model.dart';
 
 // ── Full card ─────────────────────────────────────────────────────────────────
 
@@ -74,7 +42,7 @@ class PersonalResearchCard extends ConsumerWidget {
   }
 
   Future<void> _onRun(BuildContext context, WidgetRef ref) async {
-    final rrn = await ref.read(_userRrnProvider.future);
+    final rrn = await ref.read(userRrnProvider.future);
     if (rrn == null) return;
     // Fire-and-forget — show snackbar immediately per UX spec.
     PersonalResearchService().triggerRun(rrn);
@@ -99,7 +67,7 @@ class PersonalResearchCard extends ConsumerWidget {
     );
     if (confirmed != true) return;
 
-    final rrn = await ref.read(_userRrnProvider.future);
+    final rrn = await ref.read(userRrnProvider.future);
     if (rrn == null) return;
     final ok = await PersonalResearchService().submitToCommunity(rrn, run.runId);
 

--- a/lib/ui/fleet_leaderboard/personal_research_view_model.dart
+++ b/lib/ui/fleet_leaderboard/personal_research_view_model.dart
@@ -1,0 +1,40 @@
+/// ViewModel for personal research data.
+///
+/// Exposes providers used by [PersonalResearchCard] and [PersonalResearchMiniCard].
+library;
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/personal_research.dart';
+import '../../data/services/personal_research_service.dart';
+
+/// Resolves the signed-in user's first robot RRN from Firestore.
+/// Returns null when not signed in or no robots registered.
+final userRrnProvider = FutureProvider.autoDispose<String?>((ref) async {
+  final uid = FirebaseAuth.instance.currentUser?.uid;
+  if (uid == null) return null;
+  final snap = await FirebaseFirestore.instance
+      .collection('robots')
+      .where('firebase_uid', isEqualTo: uid)
+      .limit(1)
+      .get();
+  if (snap.docs.isEmpty) return null;
+  return snap.docs.first.id;
+});
+
+/// Fetches the personal research summary for the signed-in user's first robot.
+final personalResearchProvider =
+    FutureProvider.autoDispose<PersonalResearchSummary?>((ref) async {
+  final rrn = await ref.watch(userRrnProvider.future);
+  if (rrn == null) return null;
+  return PersonalResearchService().getSummary(rrn);
+});
+
+/// Family variant scoped to a specific RRN (used by robot detail screen).
+/// Reads from Firestore stream (robots/{rrn}/telemetry/research).
+final personalResearchRrnProvider =
+    StreamProvider.autoDispose.family<PersonalResearchSummary?, String>(
+  (ref, rrn) => PersonalResearchService().summaryStream(rrn),
+);

--- a/lib/ui/robot_capabilities/capabilities_widgets.dart
+++ b/lib/ui/robot_capabilities/capabilities_widgets.dart
@@ -14,8 +14,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../data/models/robot.dart';
 import '../../ui/core/theme/app_theme.dart';
-import '../../data/models/command.dart' show CommandScope;
-import '../fleet/fleet_view_model.dart' show robotRepositoryProvider;
+import '../shared/loading_view.dart';
 
 // ── LoA enforcement command provider ─────────────────────────────────────────
 
@@ -418,7 +417,7 @@ class CapLoadingSection extends StatelessWidget {
           margin: EdgeInsets.zero,
           child: Padding(
             padding: EdgeInsets.all(24),
-            child: Center(child: CircularProgressIndicator()),
+            child: const LoadingView(),
           ),
         ),
       ],

--- a/lib/ui/robot_capabilities/components_screen.dart
+++ b/lib/ui/robot_capabilities/components_screen.dart
@@ -6,25 +6,14 @@
 /// Components are read from Firestore robots/{rrn}/components subcollection.
 library;
 
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'capabilities_widgets.dart';
+import 'components_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/loading_view.dart';
 
-// ── Provider ──────────────────────────────────────────────────────────────────
-
-final _componentsProvider =
-    StreamProvider.family<List<Map<String, dynamic>>, String>((ref, rrn) {
-  return FirebaseFirestore.instance
-      .collection('robots')
-      .doc(rrn)
-      .collection('components')
-      .snapshots()
-      .map((snap) =>
-          snap.docs.map((d) => {'id': d.id, ...d.data()}).toList()
-            ..sort((a, b) => (a['type'] as String? ?? '').compareTo(b['type'] as String? ?? '')));
-});
 
 // ── Screen ────────────────────────────────────────────────────────────────────
 
@@ -34,7 +23,7 @@ class ComponentsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final compsAsync = ref.watch(_componentsProvider(rrn));
+    final compsAsync = ref.watch(componentsProvider(rrn));
     return Scaffold(
       appBar: AppBar(
         title: const Text('Hardware Components'),
@@ -42,13 +31,13 @@ class ComponentsScreen extends ConsumerWidget {
           IconButton(
             icon: const Icon(Icons.refresh_outlined),
             tooltip: 'Re-detect components',
-            onPressed: () => ref.invalidate(_componentsProvider(rrn)),
+            onPressed: () => ref.invalidate(componentsProvider(rrn)),
           ),
         ],
       ),
       body: compsAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
+        loading: () => const LoadingView(),
+        error: (e, _) => ErrorView(error: e.toString()),
         data: (components) => components.isEmpty
             ? _EmptyComponents(rrn: rrn)
             : _ComponentsList(components: components, rrn: rrn),

--- a/lib/ui/robot_capabilities/components_view_model.dart
+++ b/lib/ui/robot_capabilities/components_view_model.dart
@@ -1,0 +1,22 @@
+/// ViewModel for the Hardware Components screen.
+///
+/// Exposes the [componentsProvider] stream that feeds [ComponentsScreen].
+library;
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Live stream of hardware components for [rrn] from Firestore
+/// `robots/{rrn}/components` subcollection.
+final componentsProvider =
+    StreamProvider.family<List<Map<String, dynamic>>, String>((ref, rrn) {
+  return FirebaseFirestore.instance
+      .collection('robots')
+      .doc(rrn)
+      .collection('components')
+      .snapshots()
+      .map((snap) =>
+          snap.docs.map((d) => {'id': d.id, ...d.data()}).toList()
+            ..sort((a, b) =>
+                (a['type'] as String? ?? '').compareTo(b['type'] as String? ?? '')));
+});

--- a/lib/ui/robot_capabilities/contribute_history_view.dart
+++ b/lib/ui/robot_capabilities/contribute_history_view.dart
@@ -4,29 +4,14 @@
 /// Reads from telemetry.contribute_history in Firestore.
 library;
 
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Provider for contribution history (last 90 days).
-final contributeHistoryProvider =
-    FutureProvider.family<List<Map<String, dynamic>>, String>((ref, rrn) async {
-  try {
-    final doc = await FirebaseFirestore.instance
-        .collection('robots')
-        .doc(rrn)
-        .collection('telemetry')
-        .doc('contribute_history')
-        .get();
-    if (!doc.exists) return [];
-    final data = doc.data();
-    if (data == null) return [];
-    final history = data['history'] as List<dynamic>? ?? [];
-    return history.cast<Map<String, dynamic>>();
-  } catch (_) {
-    return [];
-  }
-});
+import 'contribute_history_view_model.dart';
+
+import '../shared/error_view.dart';
+import '../shared/loading_view.dart';
+
 
 class ContributeHistoryView extends ConsumerWidget {
   final String rrn;
@@ -39,8 +24,8 @@ class ContributeHistoryView extends ConsumerWidget {
     final theme = Theme.of(context);
 
     return historyAsync.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(child: Text('Error: $e')),
+      loading: () => const LoadingView(),
+      error: (e, _) => ErrorView(error: e.toString()),
       data: (history) {
         if (history.isEmpty) {
           return Center(

--- a/lib/ui/robot_capabilities/contribute_history_view_model.dart
+++ b/lib/ui/robot_capabilities/contribute_history_view_model.dart
@@ -1,0 +1,29 @@
+/// ViewModel for the Contribution History view.
+///
+/// Exposes [contributeHistoryProvider] — a FutureProvider that reads the
+/// last 90 days of daily contribution records from Firestore.
+library;
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Fetches contribution history (last 90 days) for [rrn].
+/// Reads from `robots/{rrn}/telemetry/contribute_history`.
+final contributeHistoryProvider =
+    FutureProvider.family<List<Map<String, dynamic>>, String>((ref, rrn) async {
+  try {
+    final doc = await FirebaseFirestore.instance
+        .collection('robots')
+        .doc(rrn)
+        .collection('telemetry')
+        .doc('contribute_history')
+        .get();
+    if (!doc.exists) return [];
+    final data = doc.data();
+    if (data == null) return [];
+    final history = data['history'] as List<dynamic>? ?? [];
+    return history.cast<Map<String, dynamic>>();
+  } catch (_) {
+    return [];
+  }
+});

--- a/lib/ui/robot_capabilities/research_screen.dart
+++ b/lib/ui/robot_capabilities/research_screen.dart
@@ -8,6 +8,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/models/personal_research.dart';
 import '../../data/services/personal_research_service.dart';
 import '../fleet_leaderboard/personal_research_card.dart';
+import '../fleet_leaderboard/personal_research_view_model.dart';
+import '../shared/loading_view.dart';
 
 class ResearchScreen extends ConsumerStatefulWidget {
   final String rrn;
@@ -70,7 +72,7 @@ class _ResearchScreenState extends ConsumerState<ResearchScreen> {
           summaryAsync.when(
             loading: () => const Padding(
               padding: EdgeInsets.all(32),
-              child: Center(child: CircularProgressIndicator()),
+              child: const LoadingView(),
             ),
             error: (e, _) => Padding(
               padding: const EdgeInsets.all(16),

--- a/lib/ui/robot_detail/orchestrator_screen.dart
+++ b/lib/ui/robot_detail/orchestrator_screen.dart
@@ -11,27 +11,12 @@ import 'package:http/http.dart' as http;
 import '../../data/models/robot.dart';
 import '../robot_detail/robot_detail_view_model.dart';
 import '../core/theme/app_theme.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
+
 
 const _rrfBaseUrl = 'https://api.rrf.rcan.dev';
-
-// ---------------------------------------------------------------------------
-// Provider
-// ---------------------------------------------------------------------------
-
-final orchestratorsProvider = FutureProvider.family<List<Map<String, dynamic>>, String>(
-  (ref, rrn) async {
-    // In production: fetch from RRF or Firestore
-    // Returns pending + active orchestrators for this robot
-    final resp = await http.get(
-      Uri.parse('$_rrfBaseUrl/v2/orchestrators?fleet_rrn=$rrn'),
-    );
-    if (resp.statusCode == 200) {
-      final data = jsonDecode(resp.body) as Map<String, dynamic>;
-      return List<Map<String, dynamic>>.from(data['orchestrators'] as List? ?? []);
-    }
-    return [];
-  },
-);
 
 // ---------------------------------------------------------------------------
 // Screen
@@ -56,10 +41,10 @@ class OrchestratorScreen extends ConsumerWidget {
         ],
       ),
       body: robotAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
+        loading: () => const LoadingView(),
+        error: (e, _) => ErrorView(error: e.toString()),
         data: (robot) {
-          if (robot == null) return const Center(child: Text('Robot not found'));
+          if (robot == null) return const EmptyView(title: 'Robot not found');
           return _OrchestratorList(robot: robot);
         },
       ),

--- a/lib/ui/robot_detail/orchestrator_view_model.dart
+++ b/lib/ui/robot_detail/orchestrator_view_model.dart
@@ -1,0 +1,28 @@
+/// ViewModel for the Orchestrator Management screen.
+///
+/// Exposes [orchestratorsProvider] — fetches pending + active orchestrators
+/// for a robot from the RRF API.
+library;
+
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+const _rrfBaseUrl = 'https://api.rrf.rcan.dev';
+
+/// Fetches the list of orchestrators (pending + active) for [rrn] from RRF.
+final orchestratorsProvider =
+    FutureProvider.family<List<Map<String, dynamic>>, String>(
+  (ref, rrn) async {
+    final resp = await http.get(
+      Uri.parse('$_rrfBaseUrl/v2/orchestrators?fleet_rrn=$rrn'),
+    );
+    if (resp.statusCode == 200) {
+      final data = jsonDecode(resp.body) as Map<String, dynamic>;
+      return List<Map<String, dynamic>>.from(
+          data['orchestrators'] as List? ?? []);
+    }
+    return [];
+  },
+);

--- a/lib/ui/robot_detail/robot_detail_screen.dart
+++ b/lib/ui/robot_detail/robot_detail_screen.dart
@@ -11,7 +11,6 @@ library;
 
 import 'dart:convert';
 import 'dart:typed_data';
-import 'package:http/http.dart' as http;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -39,6 +38,9 @@ import '../widgets/thinking_indicator.dart';
 import 'robot_detail_view_model.dart';
 import 'slash_command_palette.dart';
 import 'slash_command_provider.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 
 enum _RobotAction { control, share, docs, capabilities, harness }
 
@@ -643,11 +645,11 @@ class _RobotDetailScreenState extends ConsumerState<RobotDetailScreen> {
 
     return robotAsync.when(
       loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (e, _) => Scaffold(body: Center(child: Text('Error: $e'))),
+          const Scaffold(body: LoadingView()),
+      error: (e, _) => Scaffold(body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
-          return const Scaffold(body: Center(child: Text('Robot not found')));
+          return const Scaffold(body: EmptyView(title: 'Robot not found'));
         }
         return _buildScaffold(context, robot, commandsAsync);
       },
@@ -785,8 +787,8 @@ class _RobotDetailScreenState extends ConsumerState<RobotDetailScreen> {
           Expanded(
             child: commandsAsync.when(
               loading: () =>
-                  const Center(child: CircularProgressIndicator()),
-              error: (e, _) => Center(child: Text('Error: $e')),
+                  const LoadingView(),
+              error: (e, _) => ErrorView(error: e.toString()),
               data: (cmds) {
                 if (cmds.isEmpty) {
                   return Center(
@@ -1200,21 +1202,6 @@ class _StatusBadge extends StatelessWidget {
 
 // ── OpenCastor version badge + latest version check ──────────────────────────
 
-/// Fetches the latest opencastor version from PyPI (cached for session).
-final _latestVersionProvider = FutureProvider<String?>((ref) async {
-  try {
-    final resp = await http.get(
-      Uri.parse('https://pypi.org/pypi/opencastor/json'),
-      headers: {'Accept': 'application/json'},
-    ).timeout(const Duration(seconds: 6));
-    if (resp.statusCode == 200) {
-      final data = jsonDecode(resp.body) as Map<String, dynamic>;
-      return (data['info'] as Map<String, dynamic>)['version'] as String?;
-    }
-  } catch (_) {}
-  return null;
-});
-
 class _VersionBadge extends ConsumerWidget {
   final String? version;
   final String rrn;
@@ -1234,7 +1221,7 @@ class _VersionBadge extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final cs = Theme.of(context).colorScheme;
-    final latestAsync = ref.watch(_latestVersionProvider);
+    final latestAsync = ref.watch(latestVersionProvider);
     final current = version;
 
     final currentBadge = Tooltip(
@@ -1379,7 +1366,7 @@ class _VersionBadge extends ConsumerWidget {
         );
         // Refresh badge after delay (pip takes ~20–30s)
         Future.delayed(const Duration(seconds: 35), () {
-          if (context.mounted) ref.invalidate(_latestVersionProvider);
+          if (context.mounted) ref.invalidate(latestVersionProvider);
         });
       }
     } catch (e) {

--- a/lib/ui/robot_detail/robot_detail_view_model.dart
+++ b/lib/ui/robot_detail/robot_detail_view_model.dart
@@ -5,7 +5,11 @@
 /// methods, it never talks to a repository directly.
 library;
 
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
 import '../../data/models/command.dart';
 import '../../data/models/robot.dart';
 import '../../data/repositories/robot_repository.dart';
@@ -57,3 +61,21 @@ final sendChatProvider =
     AsyncNotifierProvider.autoDispose<SendChatNotifier, String?>(
   SendChatNotifier.new,
 );
+
+/// Fetches the latest opencastor version from PyPI (cached for the session).
+/// Used by the version badge in [RobotDetailScreen].
+final latestVersionProvider = FutureProvider<String?>((ref) async {
+  try {
+    final resp = await http
+        .get(
+          Uri.parse('https://pypi.org/pypi/opencastor/json'),
+          headers: {'Accept': 'application/json'},
+        )
+        .timeout(const Duration(seconds: 6));
+    if (resp.statusCode == 200) {
+      final data = jsonDecode(resp.body) as Map<String, dynamic>;
+      return (data['info'] as Map<String, dynamic>)['version'] as String?;
+    }
+  } catch (_) {}
+  return null;
+});

--- a/lib/ui/shared/loading_view.dart
+++ b/lib/ui/shared/loading_view.dart
@@ -1,0 +1,26 @@
+/// Full-screen loading state widget.
+library;
+
+import 'package:flutter/material.dart';
+
+class LoadingView extends StatelessWidget {
+  final String? message;
+
+  const LoadingView({super.key, this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CircularProgressIndicator(),
+          if (message != null) ...[
+            const SizedBox(height: 16),
+            Text(message!, style: Theme.of(context).textTheme.bodySmall),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/shared/shared.dart
+++ b/lib/ui/shared/shared.dart
@@ -1,0 +1,13 @@
+/// Barrel export for shared UI widgets.
+library;
+
+export 'adaptive_navigation.dart';
+export 'confirmation_dialog.dart';
+export 'empty_view.dart';
+export 'error_view.dart';
+export 'google_sign_in_button.dart';
+export 'loading_skeleton.dart';
+export 'loading_view.dart';
+export 'pipeline_explainer.dart';
+export 'robot_card.dart';
+export 'status_indicator.dart';


### PR DESCRIPTION
Closes #50

## Summary

Migrates 9 screen-local data providers (StreamProvider / FutureProvider) out of screen files into dedicated `*_view_model.dart` files, following the MVVM architecture pattern.

## Changes

### New ViewModel files
| ViewModel | Migrated provider(s) |
|---|---|
| `alerts/alerts_view_model.dart` | `alertsProvider` |
| `fleet_leaderboard/fleet_leaderboard_view_model.dart` | `researchStatusProvider` |
| `fleet_leaderboard/personal_research_view_model.dart` | `userRrnProvider`, `personalResearchProvider`, `personalResearchRrnProvider` |
| `robot_capabilities/components_view_model.dart` | `componentsProvider` |
| `robot_capabilities/contribute_history_view_model.dart` | `contributeHistoryProvider` |
| `robot_detail/orchestrator_view_model.dart` | `orchestratorsProvider` |

### Updated existing ViewModels
- `robot_detail/robot_detail_view_model.dart`: added `latestVersionProvider` (PyPI version check)

### Screen file cleanup
- Removed provider definitions, added `import 'xxx_view_model.dart'`
- `capabilities_widgets.dart`: removed unused `CommandScope` + `robotRepositoryProvider` imports
- `research_screen.dart`: added import for `personal_research_view_model.dart`

### Bonus
- `shared/loading_view.dart`: reusable full-screen loading widget (referenced by refactored screens)
- `shared/shared.dart`: barrel export for shared widgets

## Verification
```
flutter analyze lib/  →  0 errors
```