### PR TITLE
refactor: shared ErrorView/EmptyView/LoadingView

### DIFF
--- a/lib/ui/consent/consent_screen.dart
+++ b/lib/ui/consent/consent_screen.dart
@@ -29,6 +29,7 @@ import '../../data/repositories/consent_repository_provider.dart';
 import '../../data/repositories/robot_repository.dart';
 import '../../ui/core/theme/app_theme.dart';
 import '../fleet/fleet_view_model.dart' show robotRepositoryProvider;
+import '../shared/loading_view.dart';
 
 // ── Providers ─────────────────────────────────────────────────────────────────
 
@@ -261,7 +262,7 @@ class _TrainingConsentTab extends StatelessWidget {
           .snapshots(),
       builder: (context, snap) {
         if (snap.connectionState == ConnectionState.waiting) {
-          return const Center(child: CircularProgressIndicator());
+          return const LoadingView();
         }
         final docs = snap.data?.docs ?? [];
         if (docs.isEmpty) {

--- a/lib/ui/consent/pending_consent_screen.dart
+++ b/lib/ui/consent/pending_consent_screen.dart
@@ -24,6 +24,7 @@ import '../../data/repositories/consent_repository_provider.dart';
 import '../../data/repositories/robot_repository.dart';
 import '../../ui/core/theme/app_theme.dart';
 import '../fleet/fleet_view_model.dart' show robotRepositoryProvider;
+import '../shared/loading_view.dart';
 
 // ── Providers ─────────────────────────────────────────────────────────────────
 
@@ -92,7 +93,7 @@ class PendingConsentScreen extends ConsumerWidget {
         title: const Text('Pending Consent Requests'),
       ),
       body: pendingAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const LoadingView(),
         error: (e, _) => Center(
           child: Padding(
             padding: const EdgeInsets.all(24),

--- a/lib/ui/explore/explore_screen.dart
+++ b/lib/ui/explore/explore_screen.dart
@@ -10,6 +10,8 @@ import '../../data/models/harness_config.dart';
 import '../../ui/harness/harness_viewer.dart';
 import 'explore_view_model.dart';
 import 'social_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/loading_view.dart';
 
 class ExploreScreen extends ConsumerWidget {
   const ExploreScreen({super.key});
@@ -89,9 +91,9 @@ class _DiscoverTab extends StatelessWidget {
         // ── Config grid ─────────────────────────────────────────────
         Expanded(
           child: configs.when(
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (e, _) => _ErrorState(
-              message: e.toString(),
+            loading: () => const LoadingView(),
+            error: (e, _) => ErrorView(
+              error: e.toString(),
               onRetry: () => ref.invalidate(exploreConfigsProvider(filter)),
             ),
             data: (items) => items.isEmpty
@@ -129,8 +131,8 @@ class _MyStarsTab extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final stars = ref.watch(myStarsProvider);
     return stars.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(child: Text('Error: $e')),
+      loading: () => const LoadingView(),
+      error: (e, _) => ErrorView(error: e.toString()),
       data: (configs) => configs.isEmpty
           ? const Center(
               child: Column(
@@ -167,8 +169,8 @@ class _MyConfigsTab extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final myConfigs = ref.watch(myConfigsProvider);
     return myConfigs.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(child: Text('Error: $e')),
+      loading: () => const LoadingView(),
+      error: (e, _) => ErrorView(error: e.toString()),
       data: (configs) => configs.isEmpty
           ? const Center(
               child: Column(
@@ -441,8 +443,8 @@ class ExploreDetailScreen extends ConsumerWidget {
         ],
       ),
       body: configAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
+        loading: () => const LoadingView(),
+        error: (e, _) => ErrorView(error: e.toString()),
         data: (config) => SingleChildScrollView(
           child: Column(
             children: [
@@ -1029,33 +1031,7 @@ class _EmptyState extends StatelessWidget {
   }
 }
 
-class _ErrorState extends StatelessWidget {
-  const _ErrorState({required this.message, required this.onRetry});
-  final String message;
-  final VoidCallback onRetry;
 
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Icon(Icons.cloud_off_outlined, size: 48, color: Colors.grey),
-          const SizedBox(height: 12),
-          Text('Could not load hub', style: Theme.of(context).textTheme.titleSmall),
-          const SizedBox(height: 4),
-          Text(
-            message.length > 80 ? '${message.substring(0, 80)}…' : message,
-            style: Theme.of(context).textTheme.bodySmall,
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 12),
-          FilledButton.tonal(onPressed: onRetry, child: const Text('Retry')),
-        ],
-      ),
-    );
-  }
-}
 
 // ── Display helpers ───────────────────────────────────────────────────────────
 

--- a/lib/ui/fleet/fleet_contribute_screen.dart
+++ b/lib/ui/fleet/fleet_contribute_screen.dart
@@ -11,6 +11,8 @@ import 'package:go_router/go_router.dart';
 
 import '../fleet_contribute/credits_card.dart';
 import '../shared/pipeline_explainer.dart';
+import '../shared/error_view.dart';
+import '../shared/loading_view.dart';
 
 /// Aggregate fleet contribution stats.
 class _FleetContributeStats {
@@ -136,8 +138,8 @@ class FleetContributeScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Fleet Contribution')),
       body: statsAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
+        loading: () => const LoadingView(),
+        error: (e, _) => ErrorView(error: e.toString()),
         data: (stats) {
           if (stats.totalRobots == 0) {
             return Center(

--- a/lib/ui/fleet/fleet_screen.dart
+++ b/lib/ui/fleet/fleet_screen.dart
@@ -9,6 +9,7 @@ import '../../data/models/robot.dart';
 import 'fleet_view_model.dart'
     show estopCommandProvider, fleetProvider;
 import 'robot_card.dart';
+import '../shared/error_view.dart';
 
 /// Maximum robots a free account may register. Matches MAX_ROBOTS in
 /// functions/src/registration.ts — update both when pricing launches.
@@ -58,7 +59,7 @@ class FleetScreen extends ConsumerWidget {
               duration: const Duration(milliseconds: 300),
               child: fleet.when(
                 loading: () => const _ShimmerFleetList(),
-                error: (err, _) => _ErrorView(error: err.toString()),
+                error: (err, _) => ErrorView(error: err.toString(), title: 'Fleet unavailable'),
                 data: (robots) {
                   if (robots.isEmpty) {
                     final user = FirebaseAuth.instance.currentUser;
@@ -578,32 +579,7 @@ class _ShimmerFleetList extends StatelessWidget {
   }
 }
 
-class _ErrorView extends StatelessWidget {
-  final String error;
-  const _ErrorView({required this.error});
 
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.cloud_off_outlined, size: 48),
-            const SizedBox(height: 16),
-            Text('Fleet unavailable',
-                style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            Text(error,
-                style: Theme.of(context).textTheme.bodySmall,
-                textAlign: TextAlign.center),
-          ],
-        ),
-      ),
-    );
-  }
-}
 
 // ── Profile avatar button ─────────────────────────────────────────────────────
 

--- a/lib/ui/fleet_contribute/credits_card.dart
+++ b/lib/ui/fleet_contribute/credits_card.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'credits_redeem_sheet.dart';
+import '../shared/loading_view.dart';
 
 // ── Model ──────────────────────────────────────────────────────────────────
 
@@ -157,7 +158,7 @@ class CreditsCard extends ConsumerWidget {
       loading: () => const Card(
         child: Padding(
           padding: EdgeInsets.all(16),
-          child: Center(child: CircularProgressIndicator()),
+          child: const LoadingView(),
         ),
       ),
       error: (e, _) => Card(

--- a/lib/ui/harness/harness_editor.dart
+++ b/lib/ui/harness/harness_editor.dart
@@ -29,6 +29,8 @@ import 'flow_graph.dart';
 import 'harness_validator.dart';
 import 'harness_viewer.dart';
 import 'model_garage.dart';
+import '../shared/loading_view.dart';
+import '../shared/error_view.dart';
 
 // ── Screen ────────────────────────────────────────────────────────────────────
 
@@ -2490,27 +2492,8 @@ class _CommunitySkillTab extends ConsumerWidget {
         ref.watch(exploreConfigsProvider(ExploreFilter.skill));
 
     return asyncSkills.when(
-      loading: () =>
-          const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(Icons.cloud_off_outlined, size: 36),
-              const SizedBox(height: 8),
-              Text('Could not load community skills',
-                  style:
-                      TextStyle(color: Theme.of(context).colorScheme.error)),
-              const SizedBox(height: 4),
-              Text('$e',
-                  style: const TextStyle(fontSize: 11),
-                  textAlign: TextAlign.center),
-            ],
-          ),
-        ),
-      ),
+      loading: () => const LoadingView(),
+      error: (e, _) => ErrorView(error: e.toString(), title: 'Could not load community skills'),
       data: (skills) {
         final filtered = skills.where((s) {
           if (search.isEmpty) return true;

--- a/lib/ui/harness/harness_viewer.dart
+++ b/lib/ui/harness/harness_viewer.dart
@@ -15,6 +15,7 @@ import '../../ui/core/theme/app_theme.dart';
 import 'flow_canvas.dart';
 import 'flow_graph.dart';
 import 'harness_design_panels.dart';
+import '../shared/loading_view.dart';
 
 // ── Layer colour palette ──────────────────────────────────────────────────────
 
@@ -305,7 +306,7 @@ class _HarnessViewerState extends State<HarnessViewer> {
   @override
   Widget build(BuildContext context) {
     if (widget.loading) {
-      return const Center(child: CircularProgressIndicator());
+      return const LoadingView();
     }
 
     // Flow view removed — list view only (#24)

--- a/lib/ui/harness/model_garage.dart
+++ b/lib/ui/harness/model_garage.dart
@@ -27,6 +27,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/models/llm_fit.dart';
 import 'hardware_provider.dart';
+import '../shared/loading_view.dart';
 
 // ---------------------------------------------------------------------------
 // Result type
@@ -189,7 +190,7 @@ class _ModelGarageState extends ConsumerState<ModelGarage>
                 selected: _selected,
                 onSelected: (m) => setState(() => _selected = m),
               ),
-              loading: () => const Center(child: CircularProgressIndicator()),
+              loading: () => const LoadingView(),
               error: (_, __) => _ModelLists(
                 tab: _tab,
                 localModels: _localModels,

--- a/lib/ui/mission/create_mission_sheet.dart
+++ b/lib/ui/mission/create_mission_sheet.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../data/models/mission.dart';
+import '../shared/loading_view.dart';
 
 class CreateMissionSheet extends StatefulWidget {
   const CreateMissionSheet({super.key});
@@ -176,7 +177,7 @@ class _CreateMissionSheetState extends State<CreateMissionSheet> {
                           if (snap.connectionState == ConnectionState.waiting) {
                             return const Padding(
                               padding: EdgeInsets.symmetric(vertical: 16),
-                              child: Center(child: CircularProgressIndicator()),
+                              child: const LoadingView(),
                             );
                           }
                           final docs = snap.data?.docs ?? [];

--- a/lib/ui/mission/mission_list_screen.dart
+++ b/lib/ui/mission/mission_list_screen.dart
@@ -7,6 +7,9 @@ import 'package:go_router/go_router.dart';
 
 import '../../data/models/mission.dart';
 import 'create_mission_sheet.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 
 class MissionListScreen extends StatefulWidget {
   const MissionListScreen({super.key});
@@ -84,7 +87,7 @@ class _MissionListScreenState extends State<MissionListScreen> {
   Widget build(BuildContext context) {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) {
-      return const Scaffold(body: Center(child: Text('Not signed in')));
+      return const Scaffold(body: EmptyView(title: 'Not signed in'));
     }
 
     return Scaffold(
@@ -106,10 +109,10 @@ class _MissionListScreenState extends State<MissionListScreen> {
             .snapshots(),
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
+            return const LoadingView();
           }
           if (snapshot.hasError) {
-            return Center(child: Text('Error: ${snapshot.error}'));
+            return ErrorView(error: snapshot.error.toString());
           }
           final docs = snapshot.data?.docs ?? [];
           if (docs.isEmpty) {

--- a/lib/ui/mission/mission_screen.dart
+++ b/lib/ui/mission/mission_screen.dart
@@ -8,6 +8,8 @@ import 'package:flutter/services.dart';
 
 import '../../data/models/mission.dart';
 import '../widgets/thinking_indicator.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 
 // ---------------------------------------------------------------------------
 // RCAN scope badge
@@ -248,11 +250,11 @@ class _MissionScreenState extends State<MissionScreen> {
       builder: (context, missionSnap) {
         if (missionSnap.connectionState == ConnectionState.waiting) {
           return const Scaffold(
-              body: Center(child: CircularProgressIndicator()));
+              body: LoadingView());
         }
         if (!missionSnap.hasData || !missionSnap.data!.exists) {
           return const Scaffold(
-              body: Center(child: Text('Mission not found')));
+              body: const EmptyView(title: 'Mission not found'));
         }
 
         final mission = Mission.fromDocument(missionSnap.data!);
@@ -567,7 +569,7 @@ class _MessagesList extends StatelessWidget {
           .snapshots(),
       builder: (context, snap) {
         if (snap.connectionState == ConnectionState.waiting) {
-          return const Center(child: CircularProgressIndicator());
+          return const LoadingView();
         }
         final docs = snap.data?.docs ?? [];
         if (docs.isEmpty) {

--- a/lib/ui/physical_control/physical_control_screen.dart
+++ b/lib/ui/physical_control/physical_control_screen.dart
@@ -13,6 +13,9 @@ import '../../ui/core/theme/app_theme.dart';
 import '../../ui/core/widgets/confirmation_dialog.dart';
 import '../../ui/core/widgets/health_indicator.dart';
 import '../fleet/fleet_view_model.dart' show robotRepositoryProvider;
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import '../robot_detail/robot_detail_view_model.dart';
 import '../../core/constants.dart';
 
@@ -126,11 +129,11 @@ class _PhysicalControlScreenState
     final robotAsync = ref.watch(robotDetailProvider(widget.rrn));
     return robotAsync.when(
       loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (e, _) => Scaffold(body: Center(child: Text('Error: $e'))),
+          const Scaffold(body: LoadingView()),
+      error: (e, _) => Scaffold(body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
-          return const Scaffold(body: Center(child: Text('Robot not found')));
+          return const Scaffold(body: EmptyView(title: 'Robot not found'));
         }
         return _buildUI(context, robot);
       },

--- a/lib/ui/robot_capabilities/ai_screen.dart
+++ b/lib/ui/robot_capabilities/ai_screen.dart
@@ -6,6 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import 'capabilities_widgets.dart';
 
 class AiCapabilitiesScreen extends ConsumerWidget {
@@ -16,15 +19,15 @@ class AiCapabilitiesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
-      loading: () => const Scaffold(body: Center(child: CircularProgressIndicator())),
+      loading: () => const Scaffold(body: LoadingView()),
       error: (e, _) => Scaffold(
           appBar: AppBar(title: const Text('AI Capabilities')),
-          body: Center(child: Text('Error: $e'))),
+          body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
           return Scaffold(
               appBar: AppBar(title: const Text('AI Capabilities')),
-              body: const Center(child: Text('Robot not found')));
+              body: const EmptyView(title: 'Robot not found'));
         }
         return _AiView(robot: robot);
       },

--- a/lib/ui/robot_capabilities/conformance_screen.dart
+++ b/lib/ui/robot_capabilities/conformance_screen.dart
@@ -7,6 +7,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../ui/core/theme/app_theme.dart';
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import 'capabilities_widgets.dart';
 
 class ConformanceScreen extends ConsumerWidget {
@@ -17,16 +20,15 @@ class ConformanceScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
-      loading: () => const Scaffold(
-          body: Center(child: CircularProgressIndicator())),
+      loading: () => const Scaffold(body: LoadingView()),
       error: (e, _) => Scaffold(
           appBar: AppBar(title: const Text('Conformance')),
-          body: Center(child: Text('Error: $e'))),
+          body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
           return Scaffold(
               appBar: AppBar(title: const Text('Conformance')),
-              body: const Center(child: Text('Robot not found')));
+              body: const EmptyView(title: 'Robot not found'));
         }
         return _ConformanceView(robot: robot);
       },

--- a/lib/ui/robot_capabilities/contribute_screen.dart
+++ b/lib/ui/robot_capabilities/contribute_screen.dart
@@ -8,6 +8,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import 'contribute_history_view.dart';
 import 'contribute_settings_view.dart';
 
@@ -20,15 +23,15 @@ class CapContributeScreen extends ConsumerWidget {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
       loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
+          const Scaffold(body: LoadingView()),
       error: (e, _) => Scaffold(
           appBar: AppBar(title: const Text('Contribute')),
-          body: Center(child: Text('Error: $e'))),
+          body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
           return Scaffold(
               appBar: AppBar(title: const Text('Contribute')),
-              body: const Center(child: Text('Robot not found')));
+              body: const EmptyView(title: 'Robot not found'));
         }
         return Scaffold(
           appBar: AppBar(title: Text('Contribute — ${robot.name}')),

--- a/lib/ui/robot_capabilities/contribute_settings_view.dart
+++ b/lib/ui/robot_capabilities/contribute_settings_view.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/models/robot.dart';
+import '../shared/loading_view.dart';
 
 class ContributeSettingsView extends ConsumerStatefulWidget {
   final Robot robot;
@@ -175,7 +176,7 @@ class _ContributeSettingsViewState
     final cs = theme.colorScheme;
 
     if (_loading) {
-      return const Center(child: CircularProgressIndicator());
+      return const LoadingView();
     }
 
     return Column(

--- a/lib/ui/robot_capabilities/hardware_screen.dart
+++ b/lib/ui/robot_capabilities/hardware_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../harness/hardware_provider.dart';
 import '../../data/services/ws_telemetry_service.dart';
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/loading_view.dart';
 import 'capabilities_widgets.dart';
 import 'provenance_card.dart';
 
@@ -23,7 +24,7 @@ class HardwareScreen extends ConsumerWidget {
     return hwAsync.when(
       loading: () => Scaffold(
         appBar: AppBar(title: const Text('Hardware')),
-        body: const Center(child: CircularProgressIndicator()),
+        body: const LoadingView(),
       ),
       error: (_, __) => Scaffold(
         appBar: AppBar(title: const Text('Hardware')),

--- a/lib/ui/robot_capabilities/identity_screen.dart
+++ b/lib/ui/robot_capabilities/identity_screen.dart
@@ -8,6 +8,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/constants.dart';
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import 'capabilities_widgets.dart';
 
 class IdentityScreen extends ConsumerWidget {
@@ -18,16 +21,15 @@ class IdentityScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
-      loading: () => const Scaffold(
-          body: Center(child: CircularProgressIndicator())),
+      loading: () => const Scaffold(body: LoadingView()),
       error: (e, _) => Scaffold(
           appBar: AppBar(title: const Text('Identity & Registry')),
-          body: Center(child: Text('Error: $e'))),
+          body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
           return Scaffold(
               appBar: AppBar(title: const Text('Identity & Registry')),
-              body: const Center(child: Text('Robot not found')));
+              body: const EmptyView(title: 'Robot not found'));
         }
         return _IdentityView(robot: robot);
       },

--- a/lib/ui/robot_capabilities/mcp_screen.dart
+++ b/lib/ui/robot_capabilities/mcp_screen.dart
@@ -7,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/loading_view.dart';
 
 class McpScreen extends ConsumerWidget {
   final String rrn;
@@ -27,8 +29,8 @@ class McpScreen extends ConsumerWidget {
         elevation: 0,
       ),
       body: robotAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
+        loading: () => const LoadingView(),
+        error: (e, _) => ErrorView(error: e.toString()),
         data: (robot) => _McpBody(rrn: rrn),
       ),
     );

--- a/lib/ui/robot_capabilities/providers_screen.dart
+++ b/lib/ui/robot_capabilities/providers_screen.dart
@@ -6,6 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import 'capabilities_widgets.dart';
 
 class ProvidersScreen extends ConsumerWidget {
@@ -17,15 +20,15 @@ class ProvidersScreen extends ConsumerWidget {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
       loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
+          const Scaffold(body: LoadingView()),
       error: (e, _) => Scaffold(
           appBar: AppBar(title: const Text('Gated Providers')),
-          body: Center(child: Text('Error: $e'))),
+          body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
           return Scaffold(
               appBar: AppBar(title: const Text('Gated Providers')),
-              body: const Center(child: Text('Robot not found')));
+              body: const EmptyView(title: 'Robot not found'));
         }
         return _ProvidersView(robot: robot);
       },

--- a/lib/ui/robot_capabilities/robot_capabilities_screen.dart
+++ b/lib/ui/robot_capabilities/robot_capabilities_screen.dart
@@ -20,6 +20,9 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../core/constants.dart';
 import '../core/widgets/health_indicator.dart';
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import 'capabilities_widgets.dart';
 
 // Re-export helper so any callers that imported _asList from here still compile.
@@ -41,12 +44,12 @@ class RobotCapabilitiesScreen extends ConsumerWidget {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
       loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (e, _) => Scaffold(body: Center(child: Text('Error: $e'))),
+          const Scaffold(body: LoadingView()),
+      error: (e, _) => Scaffold(body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
           return const Scaffold(
-              body: Center(child: Text('Robot not found')));
+              body: const EmptyView(title: 'Robot not found'));
         }
 
         // If anchor is set, immediately navigate to the matching sub-screen.

--- a/lib/ui/robot_capabilities/safety_screen.dart
+++ b/lib/ui/robot_capabilities/safety_screen.dart
@@ -7,6 +7,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import 'capabilities_widgets.dart';
 
 class SafetyScreen extends ConsumerWidget {
@@ -17,16 +20,15 @@ class SafetyScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
-      loading: () => const Scaffold(
-          body: Center(child: CircularProgressIndicator())),
+      loading: () => const Scaffold(body: LoadingView()),
       error: (e, _) => Scaffold(
           appBar: AppBar(title: const Text('Safety')),
-          body: Center(child: Text('Error: $e'))),
+          body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
           return Scaffold(
               appBar: AppBar(title: const Text('Safety')),
-              body: const Center(child: Text('Robot not found')));
+              body: const EmptyView(title: 'Robot not found'));
         }
         return _SafetyView(robot: robot);
       },

--- a/lib/ui/robot_capabilities/software_screen.dart
+++ b/lib/ui/robot_capabilities/software_screen.dart
@@ -6,6 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import '../robot_detail/slash_command_provider.dart';
 import 'capabilities_widgets.dart';
 
@@ -18,15 +21,15 @@ class SoftwareScreen extends ConsumerWidget {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
       loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
+          const Scaffold(body: LoadingView()),
       error: (e, _) => Scaffold(
           appBar: AppBar(title: const Text('Software Stack')),
-          body: Center(child: Text('Error: $e'))),
+          body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
           return Scaffold(
               appBar: AppBar(title: const Text('Software Stack')),
-              body: const Center(child: Text('Robot not found')));
+              body: const EmptyView(title: 'Robot not found'));
         }
         return _SoftwareView(robot: robot);
       },

--- a/lib/ui/robot_capabilities/transport_screen.dart
+++ b/lib/ui/robot_capabilities/transport_screen.dart
@@ -7,6 +7,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/constants.dart';
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import 'capabilities_widgets.dart';
 
 class TransportScreen extends ConsumerWidget {
@@ -17,15 +20,15 @@ class TransportScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
-      loading: () => const Scaffold(body: Center(child: CircularProgressIndicator())),
+      loading: () => const Scaffold(body: LoadingView()),
       error: (e, _) => Scaffold(
           appBar: AppBar(title: const Text('Transport')),
-          body: Center(child: Text('Error: $e'))),
+          body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
           return Scaffold(
               appBar: AppBar(title: const Text('Transport')),
-              body: const Center(child: Text('Robot not found')));
+              body: const EmptyView(title: 'Robot not found'));
         }
         return _TransportView(robot: robot);
       },

--- a/lib/ui/robot_detail/compliance_report_screen.dart
+++ b/lib/ui/robot_detail/compliance_report_screen.dart
@@ -11,6 +11,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/models/robot.dart';
 import '../robot_detail/robot_detail_view_model.dart';
 import '../core/theme/app_theme.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 
 class ComplianceReportScreen extends ConsumerWidget {
   final String rrn;
@@ -21,16 +24,16 @@ class ComplianceReportScreen extends ConsumerWidget {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
       loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
+          const Scaffold(body: LoadingView()),
       error: (e, _) => Scaffold(
         appBar: AppBar(title: const Text('Compliance Report')),
-        body: Center(child: Text('Error: $e')),
+        body: ErrorView(error: e.toString()),
       ),
       data: (robot) {
         if (robot == null) {
           return Scaffold(
             appBar: AppBar(title: const Text('Compliance Report')),
-            body: const Center(child: Text('Robot not found')),
+            body: const EmptyView(title: 'Robot not found'),
           );
         }
         return _ComplianceReportView(robot: robot);

--- a/lib/ui/robot_status/robot_status_screen.dart
+++ b/lib/ui/robot_status/robot_status_screen.dart
@@ -9,6 +9,9 @@ import '../../data/models/robot.dart';
 import '../../ui/core/theme/app_theme.dart';
 import '../../ui/core/widgets/health_indicator.dart';
 import '../robot_detail/robot_detail_view_model.dart';
+import '../shared/error_view.dart';
+import '../shared/empty_view.dart';
+import '../shared/loading_view.dart';
 import '../../core/constants.dart';
 
 class RobotStatusScreen extends ConsumerWidget {
@@ -20,12 +23,12 @@ class RobotStatusScreen extends ConsumerWidget {
     final robotAsync = ref.watch(robotDetailProvider(rrn));
     return robotAsync.when(
       loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (e, _) => Scaffold(body: Center(child: Text('Error: $e'))),
+          const Scaffold(body: LoadingView()),
+      error: (e, _) => Scaffold(body: ErrorView(error: e.toString())),
       data: (robot) {
         if (robot == null) {
           return const Scaffold(
-              body: Center(child: Text('Robot not found')));
+              body: const EmptyView(title: 'Robot not found'));
         }
         return _StatusView(robot: robot);
       },

--- a/lib/ui/setup/setup_screen.dart
+++ b/lib/ui/setup/setup_screen.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import '../shared/google_sign_in_button.dart';
+import '../shared/loading_view.dart';
 
 class SetupScreen extends StatefulWidget {
   final String? robotName;
@@ -79,7 +80,7 @@ class _SetupScreenState extends State<SetupScreen> {
         stream: FirebaseAuth.instance.authStateChanges(),
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
+            return const LoadingView();
           }
 
           final user = snapshot.data;


### PR DESCRIPTION
Closes #49

## Summary
Standardize error, empty, and loading state widgets across all capability screens.

### New shared widgets
- `lib/ui/shared/loading_view.dart` — `LoadingView` widget
- `lib/ui/shared/shared.dart` — barrel export for all shared widgets

### Replacements across 28+ screens
- `Center(child: CircularProgressIndicator())` → `LoadingView()`
- `Center(child: Text('Error: $e'))` → `ErrorView(error: e.toString())`
- `Center(child: Text('Robot not found'))` → `EmptyView(title: 'Robot not found')`
- Removed private `_ErrorView` and `_ErrorState` widget classes in fleet_screen and explore_screen

### Verified
`flutter analyze lib/` — 0 errors