### PR TITLE
feat: live streaming telemetry in robot detail screen (closes #58)

### DIFF
--- a/lib/ui/robot_capabilities/software_screen.dart
+++ b/lib/ui/robot_capabilities/software_screen.dart
@@ -4,6 +4,7 @@ library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../data/services/ws_telemetry_service.dart';
 
 import '../robot_detail/robot_detail_view_model.dart';
 import '../robot_detail/slash_command_provider.dart';
@@ -41,7 +42,9 @@ class _SoftwareView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final skillsAsync = ref.watch(slashCommandsProvider(robot.rrn));
-    final t = robot.telemetry;
+    // Use live WS telemetry when available; fall back to Firestore snapshot
+    final liveData = ref.watch(wsTelemetryProvider(robot.rrn)).valueOrNull;
+    final t = liveData ?? robot.telemetry;
 
     final brainPrimary = t['brain_primary'] is Map
         ? Map<String, dynamic>.from(t['brain_primary'] as Map)

--- a/lib/ui/robot_detail/robot_detail_screen.dart
+++ b/lib/ui/robot_detail/robot_detail_screen.dart
@@ -36,6 +36,7 @@ import '../fleet/fleet_view_model.dart' show robotRepositoryProvider;
 import 'chat_bubble.dart';
 import '../widgets/thinking_indicator.dart';
 import 'robot_detail_view_model.dart';
+import '../../data/services/ws_telemetry_service.dart';
 import 'slash_command_palette.dart';
 import 'slash_command_provider.dart';
 import '../shared/error_view.dart';
@@ -999,14 +1000,16 @@ class _UpdateBanner extends StatelessWidget {
 
 // ── Telemetry panel — condensed 3-item header ─────────────────────────────────
 
-class _TelemetryPanel extends StatelessWidget {
+class _TelemetryPanel extends ConsumerWidget {
   final Robot robot;
   const _TelemetryPanel({required this.robot});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final cs = Theme.of(context).colorScheme;
-    final t = robot.telemetry;
+    final wsAsync = ref.watch(wsTelemetryProvider(robot.rrn));
+    final liveData = wsAsync.valueOrNull;
+    final isLive = liveData != null;
 
     return Container(
       color: cs.surfaceContainerLow,
@@ -1032,6 +1035,18 @@ class _TelemetryPanel extends StatelessWidget {
               _VersionBadge(
                   version: robot.opencastorVersion ?? robot.version,
                   rrn: robot.rrn),
+              if (isLive) ...[
+                const SizedBox(width: 6),
+                // Live WebSocket indicator dot
+                Container(
+                  width: 6,
+                  height: 6,
+                  decoration: const BoxDecoration(
+                    color: Color(0xFF22c55e), // green-500
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              ],
               const Spacer(),
               _RobotProfileChip(rrn: robot.rrn),
             ],


### PR DESCRIPTION
## Summary
Wires the existing `wsTelemetryProvider` (already a `StreamProvider.family`) into the robot detail and capabilities screens for real-time sensor data.

## Changes
- **`_TelemetryPanel`** → `ConsumerWidget`, watches `wsTelemetryProvider(rrn)`; shows green ● dot when WS is active
- **`software_screen.dart`** → uses `liveData ?? robot.telemetry` so `active_model`, `tokens_per_sec`, `provider` update live
- **`hardware_screen.dart`** — was already wiring `wsTelemetryProvider` (pre-existing, no change needed)

## Behavior
- WS is local-network-only — connection failure is silent, Firestore fallback is automatic
- No error shown to user when WS unavailable
- Auto-reconnect with exponential backoff already implemented in `ws_telemetry_service.dart`

Closes #58