### PR TITLE
chore(deps): bump firebase_auth 5.7.0 + build_runner 2.5.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   # Firebase
   firebase_core: ^3.15.2
-  firebase_auth: ^5.0.0
+  firebase_auth: ^5.7.0
   cloud_firestore: ^5.0.0
   cloud_functions: ^5.6.2
   firebase_messaging: ^15.0.0
@@ -48,7 +48,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0
-  build_runner: ^2.4.0
+  build_runner: ^2.5.4
   riverpod_generator: ^2.4.0
   flutter_launcher_icons: ^0.14.1
 


### PR DESCRIPTION
Combines the Dependabot PRs #67 and #71 which had pubspec.lock conflicts after the batch merge. Both are safe minor version bumps.