### PR TITLE
fix: CI build.yml targets master branch (was incorrectly set to main)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build & Test
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   flutter:


### PR DESCRIPTION
The repo default branch is `master` but the CI workflow triggers on `main`. PRs targeting `master` get no CI checks. This fixes the branch name so PRs actually get validated.