### PR TITLE
fix(web): Safari login loop — proxy Firebase auth domain via Cloudflare Pages Function

### DIFF
--- a/functions/__/auth/handler.js
+++ b/functions/__/auth/handler.js
@@ -1,0 +1,49 @@
+/**
+ * Cloudflare Pages Function — Firebase Auth Domain Proxy
+ *
+ * Firebase requires the authDomain to match the app's origin so that
+ * Safari's ITP (Intelligent Tracking Prevention) doesn't block
+ * cross-origin IndexedDB access during signInWithRedirect flows.
+ *
+ * By setting authDomain: "app.opencastor.com" in firebase_options.dart,
+ * Firebase redirects to app.opencastor.com/__/auth/handler for the
+ * OAuth callback. This function proxies that request to Firebase's
+ * actual auth handler at opencastor.firebaseapp.com/__/auth/handler,
+ * which completes the OAuth flow.
+ *
+ * Result: auth state is stored in app.opencastor.com's IndexedDB
+ * (same-origin), which Safari ITP allows. getRedirectResult() succeeds.
+ *
+ * See: https://firebase.google.com/docs/auth/web/redirect-best-practices
+ */
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+  const proxyUrl = new URL(
+    `/__/auth/handler${url.search}`,
+    'https://opencastor.firebaseapp.com'
+  );
+
+  const proxied = await fetch(proxyUrl.toString(), {
+    method: context.request.method,
+    headers: {
+      ...Object.fromEntries(context.request.headers),
+      // Forward the original host so Firebase knows the auth domain
+      'X-Forwarded-Host': url.host,
+    },
+    body: ['GET', 'HEAD'].includes(context.request.method)
+      ? undefined
+      : context.request.body,
+    redirect: 'manual',
+  });
+
+  // Forward the response body and headers as-is.
+  // Do NOT follow redirects — return them so the browser handles them
+  // (Firebase auth handler may redirect back to the app).
+  const responseHeaders = new Headers(proxied.headers);
+
+  return new Response(proxied.body, {
+    status: proxied.status,
+    statusText: proxied.statusText,
+    headers: responseHeaders,
+  });
+}

--- a/functions/__/auth/iframe.js
+++ b/functions/__/auth/iframe.js
@@ -1,0 +1,25 @@
+/**
+ * Cloudflare Pages Function — Firebase Auth iFrame Proxy
+ *
+ * Firebase uses /__/auth/iframe to sync auth state between tabs
+ * via a hidden iFrame. Must be served on the same authDomain.
+ */
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+  const proxyUrl = new URL(
+    `/__/auth/iframe${url.search}`,
+    'https://opencastor.firebaseapp.com'
+  );
+
+  const proxied = await fetch(proxyUrl.toString(), {
+    method: context.request.method,
+    headers: Object.fromEntries(context.request.headers),
+    redirect: 'manual',
+  });
+
+  return new Response(proxied.body, {
+    status: proxied.status,
+    statusText: proxied.statusText,
+    headers: new Headers(proxied.headers),
+  });
+}


### PR DESCRIPTION
## Bug
iOS Safari loops on login page — tapping 'Sign in with Google' redirects through Google and comes back to /login.

## Root Cause
Safari ITP + cross-origin authDomain:
1. `signInWithPopup` fails on iOS Safari (Flutter async Dart→JS breaks user gesture context)
2. Falls back to `signInWithRedirect` → redirects to `opencastor.firebaseapp.com`
3. Google auth completes → back to `app.opencastor.com`
4. `getRedirectResult()` tries to read IndexedDB at `opencastor.firebaseapp.com` (cross-origin)
5. Safari ITP blocks it → returns null → not authenticated → back to /login → 🔁

## Fix

### This PR: Cloudflare Pages Functions
- `functions/__/auth/handler.js` — proxies `/__/auth/handler` → `opencastor.firebaseapp.com/__/auth/handler`
- `functions/__/auth/iframe.js` — proxies `/__/auth/iframe` → `opencastor.firebaseapp.com/__/auth/iframe`

This makes Firebase auth state stored in `app.opencastor.com`'s IndexedDB (same-origin), which Safari ITP allows.

### Required manual step: update `FIREBASE_OPTIONS_DART` GitHub secret
In the secret, change **one field**:
```dart
// Before:
authDomain: 'opencastor.firebaseapp.com',

// After:
authDomain: 'app.opencastor.com',
```

That tells Firebase to redirect to `app.opencastor.com/__/auth/handler` (served by this PR's Functions) instead of `opencastor.firebaseapp.com/__/auth/handler` (cross-origin, ITP-blocked).

## Verification
After merging + updating the secret:
1. Open `app.opencastor.com` in iOS Safari
2. Tap 'Sign in with Google'
3. Complete Google auth
4. Should land on /fleet (not loop back to /login)