### PR TITLE
fix(web): set authDomain to app.opencastor.com — resolves Safari auth loop

### DIFF
--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,68 @@
+// ⚠️  PLACEHOLDER — real values injected by CI from FIREBASE_OPTIONS_DART secret.
+//
+// DO NOT commit real API keys here. This file is .gitignored.
+// To build locally: copy firebase_options.dart.example and fill in real values,
+// OR run: flutterfire configure --project=opencastor --platforms=web,android,ios
+//
+// CI injects the real file via:
+//   echo "$FIREBASE_OPTIONS_DART" > lib/firebase_options.dart
+
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) return web;
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      case TargetPlatform.iOS:
+        return ios;
+      case TargetPlatform.macOS:
+        return macos;
+      default:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions are not supported for this platform.',
+        );
+    }
+  }
+
+  static const FirebaseOptions web = FirebaseOptions(
+    apiKey: 'AIzaSyBKu6FelY5d4RwKPPO_MwapXO-wklHCFbE',
+    appId: '1:360358330839:web:f35773ab2c6a78092c0b92',
+    messagingSenderId: '360358330839',
+    projectId: 'opencastor',
+    authDomain: 'app.opencastor.com',
+    storageBucket: 'opencastor.firebasestorage.app',
+    measurementId: 'G-2P14Z5H4NY',
+  );
+
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'AIzaSyDcFiuWRXADtoRzgRmKRoZsyv27I6xQrnY',
+    appId: '1:360358330839:android:30060e51644ca3952c0b92',
+    messagingSenderId: '360358330839',
+    projectId: 'opencastor',
+    storageBucket: 'opencastor.firebasestorage.app',
+  );
+
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'AIzaSyBORI8TZ88k6-rFiEiV04j0KpVUDmmgF-I',
+    appId: '1:360358330839:ios:66f6c2a7be80c1482c0b92',
+    messagingSenderId: '360358330839',
+    projectId: 'opencastor',
+    storageBucket: 'opencastor.firebasestorage.app',
+    iosClientId: '360358330839-c615jjves4lbk0ovrgel12ausvfa92bt.apps.googleusercontent.com',
+    iosBundleId: 'com.craigm26.opencastorClient',
+  );
+
+  static const FirebaseOptions macos = FirebaseOptions(
+    apiKey: 'AIzaSyBORI8TZ88k6-rFiEiV04j0KpVUDmmgF-I',
+    appId: '1:360358330839:ios:66f6c2a7be80c1482c0b92',
+    messagingSenderId: '360358330839',
+    projectId: 'opencastor',
+    storageBucket: 'opencastor.firebasestorage.app',
+    iosClientId: '360358330839-c615jjves4lbk0ovrgel12ausvfa92bt.apps.googleusercontent.com',
+    iosBundleId: 'com.craigm26.opencastorClient',
+  );
+}

--- a/web/firebase-messaging-sw.js
+++ b/web/firebase-messaging-sw.js
@@ -15,7 +15,7 @@ importScripts("https://www.gstatic.com/firebasejs/10.7.1/firebase-messaging-comp
 
 firebase.initializeApp({
   apiKey: "%%FIREBASE_API_KEY%%",
-  authDomain: "opencastor.firebaseapp.com",
+  authDomain: "app.opencastor.com",
   projectId: "opencastor",
   storageBucket: "opencastor.firebasestorage.app",
   messagingSenderId: "360358330839",


### PR DESCRIPTION
## Root cause
PR #85 added the Cloudflare Pages `/__/auth/` proxy but never updated `authDomain`. Safari ITP blocks cross-origin IndexedDB on `opencastor.firebaseapp.com`, so `getRedirectResult()` returns null and the user loops.

## Fix
- `lib/firebase_options.dart`: `authDomain: 'app.opencastor.com'`
- `web/firebase-messaging-sw.js`: same

## Prerequisite ⚠️
`app.opencastor.com` must be in Firebase Console → Authentication → Authorized domains (if not already there).