### PR TITLE
fix(web): use redirect on iOS Safari; widen popup error fallback

### DIFF
--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -1,22 +1,26 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:web/web.dart' as web;
 import '../../core/app_logger.dart';
 
 /// Centralises all authentication logic.
 ///
 /// Web auth strategy (per Firebase docs + flutter/web constraints):
-///   1. Use signInWithPopup — this is the documented primary method.
-///      Firebase handles the entire flow on opencastor.firebaseapp.com,
+///   1. iOS Safari: skip signInWithPopup entirely — Flutter web canvas apps
+///      cannot reliably propagate user gestures to the window level on
+///      iPhone/iPad, so popups fail silently. Go straight to redirect.
+///   2. Other browsers: Use signInWithPopup — this is the documented primary
+///      method. Firebase handles the entire flow on opencastor.firebaseapp.com,
 ///      so no cross-origin storage issues.
-///   2. The Cloudflare Pages _headers file sets:
+///   3. The Cloudflare Pages _headers file sets:
 ///         Cross-Origin-Opener-Policy: same-origin-allow-popups
 ///      which allows the popup to post the auth result back to the opener.
-///   3. Fallback to signInWithRedirect ONLY for browsers that block all
-///      popups (popup-blocked, cancelled-popup-request). getRedirectResult()
+///   4. Fallback to signInWithRedirect for browsers that block popups or
+///      return a popup-related FirebaseAuthException. getRedirectResult()
 ///      in main() catches the result on return.
 ///
-/// Why not redirect-first:
+/// Why not redirect-first (non-iOS):
 ///   signInWithRedirect stores pending state in IndexedDB on the authDomain
 ///   (opencastor.firebaseapp.com). Modern browsers with strict privacy
 ///   settings block cross-origin storage access from app.opencastor.com,
@@ -54,11 +58,39 @@ class AuthService {
 
   /// Initiate Google sign-in.
   ///
-  /// Web: signInWithPopup (primary) → signInWithRedirect (popup-blocked fallback).
+  /// Web: iOS Safari → signInWithRedirect directly.
+  ///      Other browsers → signInWithPopup (primary) → signInWithRedirect
+  ///      fallback for any popup-related FirebaseAuthException.
   /// Native: GoogleSignIn plugin → Firebase credential.
   static Future<void> signInWithGoogle() async {
     log.i('AuthService: signInWithGoogle() — isWeb=$kIsWeb');
     if (kIsWeb) {
+      // iOS Safari cannot reliably open popups from Flutter web canvas apps —
+      // the canvas rendering model doesn't propagate user gestures to the
+      // window level. Skip signInWithPopup and go straight to redirect.
+      final userAgent =
+          web.window.navigator.userAgent.toLowerCase();
+      final isIosSafari =
+          userAgent.contains('iphone') || userAgent.contains('ipad');
+
+      if (isIosSafari) {
+        log.i(
+          'AuthService: iOS Safari detected — using signInWithRedirect directly',
+        );
+        await FirebaseAuth.instance.signInWithRedirect(_googleProvider);
+        return;
+      }
+
+      // Error codes where popup failed for environmental reasons — fall back
+      // to redirect rather than surfacing an error to the user.
+      const popupFallbackCodes = {
+        'popup-blocked',
+        'cancelled-popup-request',
+        'web-context-cancelled',
+        'operation-not-supported-in-this-environment',
+        'web-storage-unsupported',
+      };
+
       try {
         final cred =
             await FirebaseAuth.instance.signInWithPopup(_googleProvider);
@@ -67,11 +99,9 @@ class AuthService {
         );
         return;
       } on FirebaseAuthException catch (e) {
-        // Only fall back to redirect if the popup was truly blocked by the
-        // browser's popup blocker — not for COOP or auth errors.
-        if (e.code == 'popup-blocked' || e.code == 'cancelled-popup-request') {
+        if (popupFallbackCodes.contains(e.code)) {
           log.w(
-            'AuthService: popup blocked (${e.code}), falling back to redirect',
+            'AuthService: popup failed (${e.code}), falling back to redirect',
           );
           await FirebaseAuth.instance.signInWithRedirect(_googleProvider);
         } else {

--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -1,7 +1,8 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
-import 'package:web/web.dart' as web;
+import 'ua_detector_stub.dart'
+    if (dart.library.js_interop) 'ua_detector_web.dart';
 import '../../core/app_logger.dart';
 
 /// Centralises all authentication logic.
@@ -68,12 +69,7 @@ class AuthService {
       // iOS Safari cannot reliably open popups from Flutter web canvas apps —
       // the canvas rendering model doesn't propagate user gestures to the
       // window level. Skip signInWithPopup and go straight to redirect.
-      final userAgent =
-          web.window.navigator.userAgent.toLowerCase();
-      final isIosSafari =
-          userAgent.contains('iphone') || userAgent.contains('ipad');
-
-      if (isIosSafari) {
+      if (isMobileSafari()) {
         log.i(
           'AuthService: iOS Safari detected — using signInWithRedirect directly',
         );

--- a/lib/data/services/ua_detector_stub.dart
+++ b/lib/data/services/ua_detector_stub.dart
@@ -1,0 +1,2 @@
+/// Stub for non-web platforms — UA is never iOS Safari.
+bool isMobileSafari() => false;

--- a/lib/data/services/ua_detector_web.dart
+++ b/lib/data/services/ua_detector_web.dart
@@ -1,0 +1,7 @@
+import 'package:web/web.dart' as web;
+
+/// Returns true if running on iPhone or iPad Safari.
+bool isMobileSafari() {
+  final ua = web.window.navigator.userAgent.toLowerCase();
+  return ua.contains('iphone') || ua.contains('ipad');
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -556,42 +556,42 @@ packages:
     dependency: "direct main"
     description:
       name: google_sign_in
-      sha256: d0a2c3bcb06e607bb11e4daca48bd4b6120f0bbc4015ccebbe757d24ea60ed2a
+      sha256: "521031b65853b4409b8213c0387d57edaad7e2a949ce6dea0d8b2afc9cb29763"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "7.2.0"
   google_sign_in_android:
     dependency: transitive
     description:
       name: google_sign_in_android
-      sha256: d5e23c56a4b84b6427552f1cf3f98f716db3b1d1a647f16b96dbb5b93afa2805
+      sha256: be0d0733a6a7c5da165879d844a239aa87587a3c767a9163faedde581f731f76
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "7.2.10"
   google_sign_in_ios:
     dependency: transitive
     description:
       name: google_sign_in_ios
-      sha256: "102005f498ce18442e7158f6791033bbc15ad2dcc0afa4cf4752e2722a516c96"
+      sha256: ac1e4c1205267cb7999d1d81333fccffdfda29e853f434bbaf71525498bb6950
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.0"
+    version: "6.3.0"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
-      sha256: "5f6f79cf139c197261adb6ac024577518ae48fdff8e53205c5373b5f6430a8aa"
+      sha256: "7f59208c42b415a3cca203571128d6f84f885fead2d5b53eb65a9e27f2965bb5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "3.1.0"
   google_sign_in_web:
     dependency: transitive
     description:
       name: google_sign_in_web
-      sha256: "460547beb4962b7623ac0fb8122d6b8268c951cf0b646dd150d60498430e4ded"
+      sha256: d473003eeca892f96a01a64fc803378be765071cb0c265ee872c7f8683245d14
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.4+4"
+    version: "1.1.3"
   graphs:
     dependency: transitive
     description:
@@ -780,18 +780,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1161,10 +1161,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   timeago:
     dependency: "direct main"
     description:
@@ -1286,7 +1286,7 @@ packages:
     source: hosted
     version: "1.2.1"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,9 @@ dependencies:
   flutter_riverpod: ^2.5.1
   logger: ^2.4.0
 
+  # Platform
+  web: ^1.1.1
+
   # Utils
   intl: ^0.19.0
   timeago: ^3.6.1


### PR DESCRIPTION
## Summary

Fixes persistent auth loop on iOS Safari.

- iOS Safari cannot reliably open popups from Flutter web canvas apps — skip signInWithPopup and go straight to signInWithRedirect on iPhone/iPad
- Widen popup fallback: also redirect on `web-context-cancelled`, `operation-not-supported-in-this-environment`, `web-storage-unsupported` (previously these were rethrown, causing error state instead of redirect)

authDomain fix (#96) is prerequisite — already deployed.

## Test plan
- [ ] Sign in on iOS Safari (iPhone/iPad) — should redirect directly without attempting popup
- [ ] Sign in on desktop Chrome — should still use popup (no change)
- [ ] Sign in on a browser that blocks popups — should fall back to redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)