### PR TITLE
fix: auth timeout loop — 10s timer was kicking users to /login every 10s

### DIFF
--- a/lib/ui/fleet/fleet_view_model.dart
+++ b/lib/ui/fleet/fleet_view_model.dart
@@ -28,21 +28,39 @@ export '../../data/repositories/robot_repository_provider.dart'
 // ---------------------------------------------------------------------------
 
 /// Auth state stream — single source of truth for sign-in status.
-final authStateProvider = StreamProvider<User?>(
-  (_) {
-    // On iOS, authStateChanges() can take several seconds on first launch
-    // while Firebase checks persisted credentials. Without a timeout the
-    // router stays at /splash indefinitely (dark bg looks like black screen).
-    // After 8s we emit null (unauthenticated) so the router falls through to
-    // /login instead of looping at /splash forever.
-    return FirebaseAuth.instance
-        .authStateChanges()
-        .timeout(
-          const Duration(seconds: 8),
-          onTimeout: (sink) => sink.add(null),
-        );
-  },
-);
+final authStateProvider = StreamProvider<User?>((_) async* {
+  // On iOS, Firebase checks persisted credentials asynchronously — the first
+  // authStateChanges() event can arrive several seconds after cold start.
+  // Without a guard the router would sit on /splash forever (looks like a
+  // black-screen crash).
+  //
+  // Fix: race the first emission against a 10s deadline. If no event arrives
+  // in time we yield null so the router falls through to /login.
+  //
+  // IMPORTANT: the timeout applies ONLY to the first emission. After that the
+  // stream passes through with no timeout. The previous implementation used
+  // .timeout() on the entire stream, which re-arms every 10 s of inactivity
+  // (i.e. while the user is authenticated and auth state is stable). That
+  // caused a hard redirect to /login after ~10 s on any screen — the
+  // "auth loop on robot detail" bug.
+  final stream = FirebaseAuth.instance.authStateChanges();
+  bool firstEmitted = false;
+
+  await for (final user in stream.timeout(
+    const Duration(seconds: 10),
+    onTimeout: (sink) {
+      if (!firstEmitted) sink.add(null); // only emit null if still waiting
+    },
+  )) {
+    firstEmitted = true;
+    yield user;
+    // After the first value, break out and re-subscribe WITHOUT a timeout
+    break;
+  }
+
+  // Tail: pass remaining events through with no timeout
+  yield* stream;
+});
 
 // ---------------------------------------------------------------------------
 // Fleet data stream


### PR DESCRIPTION
## Root cause
`authStateProvider` used `.timeout(10s, onTimeout: emit null)` on the entire `authStateChanges()` stream. Dart's `Stream.timeout()` re-arms after each event — so with a stable auth state (no sign-in/out for >10s), it fires `null` every 10 seconds, triggering the router redirect to `/login`.

This is why opening robot detail and staying a few seconds caused an auth loop.

## Fix
Apply the 10s timeout only to the **first** emission (the iOS cold-start guard). After the first auth state event arrives, switch to an untimed tail subscription that just passes events through.

## Before / After
- Before: user gets kicked to /login after ~10s on any screen
- After: iOS cold-start splash timeout still works; authenticated users stay logged in indefinitely