### PR TITLE
fix(web): auth loop — await auth init before runApp; stop SW mid-session reload

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,6 +50,23 @@ Future<void> main() async {
     await AuthService.handleRedirectResult()
         .timeout(const Duration(seconds: 5), onTimeout: () {});
 
+    // On web, Firebase Auth resolves persisted credentials from IndexedDB
+    // asynchronously AFTER initializeApp(). Until it resolves, currentUser
+    // is null and authStateChanges() emits null — causing the router to
+    // briefly redirect to /login before the real user is emitted.
+    //
+    // Fix: wait for the first authStateChanges() emission here, before
+    // runApp(). After this point, Firebase Auth is fully initialized and
+    // any new subscription to authStateChanges() emits the stable state
+    // immediately (no transient null). The 5s timeout is a safety valve
+    // for offline/slow-network cold starts.
+    if (kIsWeb) {
+      await FirebaseAuth.instance
+          .authStateChanges()
+          .first
+          .timeout(const Duration(seconds: 5), onTimeout: () => null);
+    }
+
     // Register native background message handler (web uses firebase-messaging-sw.js).
     if (!kIsWeb) FirebaseMessaging.onBackgroundMessage(_fcmBackgroundHandler);
 

--- a/web/index.html
+++ b/web/index.html
@@ -100,28 +100,25 @@
       });
     })();
     if ('serviceWorker' in navigator) {
-      // If a SW is already controlling, immediately trigger an update check.
+      // Trigger a background SW update check on every page load.
+      // The new SW downloads silently and waits — it does NOT activate
+      // immediately (no SKIP_WAITING) and does NOT force a page reload.
+      //
+      // Why no auto-reload:
+      //   The previous pattern sent SKIP_WAITING + reloaded on controllerchange.
+      //   This caused mid-session page reloads on every deploy. During reload,
+      //   Firebase Auth briefly emits null before re-reading IndexedDB, which
+      //   the router interpreted as "signed out" and redirected to /login —
+      //   the root cause of the auth loop on robot detail.
+      //
+      // New SW activates on the user's next natural page load (close + reopen,
+      // or manual refresh). Users get updates within one session boundary with
+      // no disruption to the current session.
       if (navigator.serviceWorker.controller) {
         navigator.serviceWorker.controller.postMessage({ type: 'CHECK_FOR_UPDATE' });
       }
       navigator.serviceWorker.getRegistrations().then(function(regs) {
         regs.forEach(function(reg) { reg.update(); });
-      });
-      navigator.serviceWorker.addEventListener('controllerchange', function() {
-        window.location.reload();
-      });
-      navigator.serviceWorker.ready.then(function(reg) {
-        if (reg.waiting) {
-          reg.waiting.postMessage({ type: 'SKIP_WAITING' });
-        }
-        reg.addEventListener('updatefound', function() {
-          var newWorker = reg.installing;
-          newWorker.addEventListener('statechange', function() {
-            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-              newWorker.postMessage({ type: 'SKIP_WAITING' });
-            }
-          });
-        });
       });
     }
   </script>


### PR DESCRIPTION
## Root cause (two contributing issues)\n\n### 1. Service worker forced mid-session reload\n`index.html` was calling `SKIP_WAITING` + `window.location.reload()` on `controllerchange`. With 5+ deploys today, this fired on every visit. Each reload caused Firebase Auth to re-initialize from scratch.\n\n### 2. `authStateChanges()` initial null on web\nFirebase web SDK ALWAYS emits `null` first on any new auth subscription, before the async IndexedDB check completes. After a SW reload, `runApp()` created a fresh auth subscription, got `null`, and the router redirected to `/login` before the real user arrived.\n\n## Fixes\n- **main.dart**: `await authStateChanges().first` before `runApp()` — Firebase Auth is fully initialized by the time the widget tree builds. No more transient null.\n- **index.html**: removed `SKIP_WAITING` + `controllerchange → reload`. New SW activates on next natural page load (close + reopen or manual refresh). No mid-session disruption.