### PR TITLE
Plan 7 Phase 3: forbidden-phrase-lint workflow + 5 RCAN version dehardcodes

### DIFF
--- a/.github/workflows/forbidden-phrase-lint.yml
+++ b/.github/workflows/forbidden-phrase-lint.yml
@@ -1,0 +1,48 @@
+name: forbidden-phrase-lint
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'SECURITY.md'
+      - 'CHANGELOG.md'
+      - '.github/workflows/forbidden-phrase-lint.yml'
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Fetch lint + dictionary from opencastor-ops
+        env:
+          AUTH_TOKEN: ${{ secrets.OPENCASTOR_OPS_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          API="https://api.github.com/repos/craigm26/opencastor-ops/contents"
+          REF="master"
+          mkdir -p .forbidden-phrase-lint
+          curl -fsSL \
+            -H "Authorization: Bearer ${AUTH_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            "${API}/tools/lint_forbidden_phrases.py?ref=${REF}" \
+            -o .forbidden-phrase-lint/lint.py
+          curl -fsSL \
+            -H "Authorization: Bearer ${AUTH_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            "${API}/docs/standards/forbidden-phrases.json?ref=${REF}" \
+            -o .forbidden-phrase-lint/dict.json
+      - name: Run lint
+        run: |
+          set -euo pipefail
+          python .forbidden-phrase-lint/lint.py \
+            --dict .forbidden-phrase-lint/dict.json \
+            --root .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ Robot (castor bridge) ──outbound──▶ Firestore ◀── Flutter app
 
 ## RCAN Protocol
 
-This client implements the consumer side of [RCAN v1.6.1](https://rcan.dev):
+This client implements the consumer side of the [RCAN protocol](https://rcan.dev):
 
 - **RRN** (Robot Resource Name): `RRN-000000000001` format — unique robot identifier
 - **RURI** (Robot URI): `rcan://[org].[model].[instance]` — routing address

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Web dashboard for managing your OpenCastor robot fleet — real-time monitoring, control, ESTOP, and consent management from any browser.
 
 [![Live](https://img.shields.io/badge/live-app.opencastor.com-orange)](https://app.opencastor.com)
-[![RCAN Spec](https://img.shields.io/badge/RCAN-v1.6-blue)](https://rcan.dev/spec/)
+[![RCAN](https://img.shields.io/badge/RCAN-protocol-blue)](https://rcan.dev/compatibility)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green)](LICENSE)
 
 **Live at [app.opencastor.com](https://app.opencastor.com)**
@@ -11,13 +11,13 @@ Web dashboard for managing your OpenCastor robot fleet — real-time monitoring,
 ## What It Does
 
 - **Fleet overview** — real-time status cards for all your robots; one-tap ESTOP on every screen
-- **Robot detail** — telemetry, command history, RCAN v1.6 capability badges (transport, LoA, federation)
+- **Robot detail** — telemetry, command history, [RCAN protocol](https://rcan.dev/compatibility) capability badges (transport, LoA, federation)
 - **Chat control** — send instructions in natural language via the chat interface
 - **Control panel** — arm teleop with confirmation modal + persistent ESTOP button
 - **Consent management** — approve/deny R2RAM access requests; view and revoke established peer consent
 - **Revocation display** — badges show when a robot's RCAN identity is revoked
 - **LoA display** — shows operator Level of Assurance on each control command
-- **Multi-modal stub** — media attachment UI for RCAN v1.6 multi-modal payloads
+- **Multi-modal stub** — media attachment UI for [RCAN protocol](https://rcan.dev/compatibility) multi-modal payloads
 
 ## Tech Stack
 
@@ -102,7 +102,7 @@ castor bridge --config bob.rcan.yaml
 
 The bridge connects outbound to Firestore. Your robot appears in the fleet dashboard within 30 seconds.
 
-## RCAN v1.6 Features
+## RCAN Protocol Features
 
 | Feature | UI Location |
 |---|---|
@@ -110,7 +110,7 @@ The bridge connects outbound to Firestore. Your robot appears in the fleet dashb
 | Revocation badges | Robot detail — red badge if RRN is revoked |
 | LoA display | Command history — operator LoA shown per command |
 | Transport badges | Robot detail — HTTP / Compact / Minimal transport indicators |
-| Multi-modal stub | Chat — attach media for RCAN v1.6 multi-modal payloads |
+| Multi-modal stub | Chat — attach media for [RCAN protocol](https://rcan.dev/compatibility) multi-modal payloads |
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- Adds inline-form `forbidden-phrase-lint` workflow per Plan 2 lessons §A.
- Fixes **5 violations** of phrase `rcan-version-hardcoded`: 4 in `README.md` (badge + 3 inline mentions) + 1 in `CLAUDE.md`.
- Replacement strategy: link to live `https://rcan.dev/compatibility` matrix instead of hardcoded version string. Matches Plan 2's §J SDK README cleanup pattern.
- Lint goes from `total_hits=5` → `0`.

## Test plan
- [ ] `OPENCASTOR_OPS_READ_TOKEN` secret added to repo
- [ ] Workflow re-runs clean
- [ ] Visual check: README badge still renders (now points at `/compatibility` instead of `/spec/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)