### PR TITLE
fix(core): derive versionLabel from appVersion + rcanVersion

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -6,7 +6,7 @@ class AppConstants {
 
   static const String appVersion = '1.5.0';
   static const String rcanVersion = '3.0';
-  static const String versionLabel = 'v1.5.0 · RCAN v3.0';
+  static const String versionLabel = 'v$appVersion · RCAN v$rcanVersion';
   static const String opencastorReleaseVersion = '2026.3.29.1';
 
   // Documentation URLs


### PR DESCRIPTION
## Summary
- \`versionLabel\` was a hardcoded concatenation (\`'v1.5.0 · RCAN v3.0'\`) of two consts that already exist on the same class. Now derived via const string interpolation.
- Bumping \`appVersion\` or \`rcanVersion\` now requires editing one line, not three.
- Same emitted string at runtime — zero behavior change.

## Why this PR is small
This fixes the only true \`rcan-version-hardcoded\` violation in \`lib/\` from Plan 9 Phase 0 baseline lint. The other 41 hits in the same scan are code-provenance comments (schema-evolution markers in \`robot.dart\`) and spec-section citations — they're out-of-scope per Plan 7 §K (Dart source is not a marketing surface). Those will be unflagged by adding \`path_scope\` to \`forbidden-phrases.json\` in \`opencastor-ops\` (separate PR).

## Test plan
- [x] \`flutter analyze\` — clean (No issues found)
- [x] \`flutter test\` — 11/11 pass
- [ ] Reviewer confirms callsite \`lib/app.dart:888\` still renders the same fallback string

## Refs
- Plan body: \`opencastor-ops/docs/superpowers/plans/2026-05-04-apex-site-text-accuracy.md\` (Plan 9)
- Baseline scan: \`opencastor-ops/operations/2026-05-05-apex-text-accuracy/baseline-lint.txt\`
- Plan 7 §K: \`opencastor-ops/docs/superpowers/plans/2026-05-04-adjacent-and-demo.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)