### PR TITLE
ci: drop tag-push auto-trigger on TestFlight workflow (cost control)

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,5 +1,8 @@
 name: iOS TestFlight
 
+# Manual-trigger only as of 2026-05-08 — the `push: tags: v*` auto-trigger was
+# removed to prevent a release tag from auto-firing macOS-runner time.
+# To ship a TF build: tag locally, then `gh workflow run iOS\ TestFlight --ref v<x.y.z>`.
 on:
   workflow_dispatch:
     inputs:
@@ -7,9 +10,6 @@ on:
         description: "Build note (e.g. 'competition UI')"
         required: false
         default: ""
-  push:
-    tags:
-      - 'v*'
 
 jobs:
   testflight:


### PR DESCRIPTION
## Summary

GitHub Actions monthly macOS budget exhausted across the ecosystem. Drop
`push: tags: v*` from `testflight.yml` so a release tag does not auto-fire
macOS-runner time (10× multiplier on macos-15) on top of unrelated CI runs.

The workflow remains triggerable manually via `workflow_dispatch`.

## Change

`.github/workflows/testflight.yml` — drop `push: tags: v*`. Keeps `workflow_dispatch` with the existing `version_suffix` input.

## How to trigger manually after this lands

```bash
git tag v<x.y.z>
gh workflow run "iOS TestFlight" --ref v<x.y.z>
# or with the build-note input:
gh workflow run "iOS TestFlight" --ref v<x.y.z> -f version_suffix="competition UI"
```

Reversible — revert this commit to restore the tag-push trigger if the budget rebalances.

## Sibling PR

[craigm26/HeatSentry](https://github.com/craigm26/HeatSentry/pulls?q=is:pr+ci:disable+ios+auto-triggers) does the same thing across the iOS-build + TestFlight workflows in that repo. Same root cause (macOS-runner time exhausted by automatic triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)