### PR TITLE
docs(claude-md): fix stale ecosystem-list facts (Plan 9 carryover)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,10 @@ Deployed at **[app.opencastor.com](https://app.opencastor.com)** via Cloudflare 
 | [craigm26/OpenCastor](https://github.com/craigm26/OpenCastor) | Robot runtime (Python). `castor` CLI, Protocol 66 safety layer, RCAN router, `castor bridge` daemon. | `main` |
 | [craigm26/opencastor-client](https://github.com/craigm26/opencastor-client) | **This repo.** Flutter web fleet management app. | `master` |
 | [craigm26/opencastor-ops](https://github.com/craigm26/opencastor-ops) | Private. Business, legal, compliance, infrastructure docs. | `main` |
-| [continuonai/rcan-spec](https://github.com/continuonai/rcan-spec) | RCAN protocol specification (v1.6.1). Astro site at rcan.dev. | `master` |
-| [continuonai/rcan-py](https://github.com/continuonai/rcan-py) | Python RCAN SDK (v0.6.0). `pip install rcan`. | `main` |
-| [continuonai/rcan-ts](https://github.com/continuonai/rcan-ts) | TypeScript RCAN SDK (v0.6.0). `npm install @continuonai/rcan`. | `master` |
-| [continuonai/RobotRegistryFoundation](https://github.com/continuonai/RobotRegistryFoundation) | Robot Registry Foundation — canonical RRN records. | `main` |
+| [continuonai/rcan-spec](https://github.com/continuonai/rcan-spec) | RCAN protocol specification. Astro site at rcan.dev. Canonical version: see [rcan.dev/compatibility](https://rcan.dev/compatibility) (current `rcan_spec_version` in `opencastor-ops/config/repos.json`: 3.2). | `master` |
+| [continuonai/rcan-py](https://github.com/continuonai/rcan-py) | Python RCAN SDK. `pip install rcan` (PyPI canonical name is `rcan`, currently v3.4.0; verify with `pip index versions rcan`). | `main` |
+| [continuonai/rcan-ts](https://github.com/continuonai/rcan-ts) | TypeScript RCAN SDK. `npm install rcan-ts` (npm published name is `rcan-ts`, currently v3.4.2 — NOT `@continuonai/rcan`; verify with `npm view rcan-ts version`). | `master` |
+| [craigm26/RobotRegistryFoundation](https://github.com/craigm26/RobotRegistryFoundation) | Robot Registry Foundation — neutral identity and evidence registry (Layer 6 per spec §3). Site at robotregistryfoundation.org. | `main` |
 | [craigm26/personalsite](https://github.com/craigm26/personalsite) | craigmerry.com — Astro + Cloudflare Pages. | `main` |
 
 ---
@@ -241,7 +241,7 @@ This client implements the consumer side of the [RCAN protocol](https://rcan.dev
   - Scopes: `discover(0) < status(1) < chat(2) < control(3) < safety(99)`
   - Higher scope satisfies lower (control implies chat)
   - ESTOP: any authenticated owner can send regardless of scope
-- **Message types**: 20 types including CONSENT_REQUEST (20), CONSENT_GRANT (21), CONSENT_DENY (22)
+- **Message types**: defined in `rcan-py/rcan/message.py` (currently 44 types; integer assignments stable per spec). Notable: CONSENT_REQUEST (20), CONSENT_GRANT (21), CONSENT_DENY (22). See [rcan.dev/compatibility](https://rcan.dev/compatibility) for current count + spec version.
 
 ---
 


### PR DESCRIPTION
## Summary

Plan 9 audit ([Phase 4](https://github.com/craigm26/opencastor-ops/blob/master/operations/2026-05-05-apex-text-accuracy/findings-app-opencastor.md) + [lessons-learned](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/lessons-learned/2026-05-08-plan-9-execution.md) open question §4) surfaced stale ecosystem-table entries in this repo's `CLAUDE.md`. CLAUDE.md is dev-facing (not user-visible) so it was out of Plan 9 PR scope, but the drift was specific enough to fix mechanically — this is the carryover.

## Diff

5 fixes, 1 file (CLAUDE.md), +5/-5:

| Line | Drift | Fix |
|---|---|---|
| 17 | rcan-spec "(v1.6.1)" | link to rcan.dev/compatibility + note canonical `rcan_spec_version: 3.2` per `opencastor-ops/config/repos.json` |
| 18 | rcan-py "(v0.6.0)" | bump to v3.4.0 per live `~/rcan-py/pyproject.toml` |
| 19 | rcan-ts "(v0.6.0). `npm install @continuonai/rcan`" | npm published name is **`rcan-ts`** (v3.4.2); `@continuonai/rcan` returns 404 from npm registry — same broken-link bug fixed in [PR #128](https://github.com/craigm26/opencastor-client/pull/128) (F-OCC-03/08) |
| 20 | wrong org `continuonai/RobotRegistryFoundation`; description "canonical RRN records" | correct org `craigm26/RobotRegistryFoundation`; canonical Layer-6 charter from spec §3 ("neutral identity and evidence registry") |
| 244 | "Message types: 20 types" | 44 types (current rcan-py); CONSENT_REQUEST=20/GRANT=21/DENY=22 still accurate; add link to rcan.dev/compatibility for live count |

## Verification (live, 2026-05-08)

- `curl -s https://pypi.org/pypi/rcan/json | jq -r .info.version` → `3.4.0`
- `curl -s https://registry.npmjs.org/rcan-ts | jq -r '."dist-tags".latest'` → `3.4.2`
- `curl -s https://registry.npmjs.org/@continuonai%2Frcan` → `{"error":"Not found"}` (confirms `@continuonai/rcan` NOT published)
- `opencastor-ops/config/repos.json` `rcan_spec_version: "3.2"`
- `grep -cE '^\s+[A-Z_]+ = [0-9]+' ~/rcan-py/rcan/message.py` → `44`

## Deferred

`Recent Features (2026-03-19)` section (line 264) is 7 weeks stale but updating requires curating current features — operator content task, not mechanical drift fix. Per Plan 9 lessons-learned §F (sub-finding deferral pattern: content creation belongs in a separate issue), not bundled here.

## No code changes

CLAUDE.md is dev-facing documentation. No Flutter analyzer / test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)